### PR TITLE
fix: align file tree chevrons

### DIFF
--- a/src/browser/lib/Bridge.ts
+++ b/src/browser/lib/Bridge.ts
@@ -388,45 +388,45 @@ export class Bridge {
         const span = document.createElement('span');
         span.classList.add('file-name');
 
-        const icon = document.createElement('i');
-        icon.className =
-          node.type === 'directory' ? 'fa fa-folder me-1' : 'fa fa-file me-1';
-
-        let chevron: HTMLElement | null = null;
-        if (node.type === 'directory') {
-          chevron = document.createElement('i');
-          chevron.className = node.children?.length
-            ? 'fa fa-chevron-right me-1'
-            : 'fa fa-chevron-right me-1 invisible';
-          chevron.style.fontSize = '0.7em';
-          span.appendChild(chevron);
+        const chevron = document.createElement('span');
+        chevron.classList.add('me-1');
+        chevron.innerHTML = '<i class="fa fa-chevron-right"></i>';
+        if (node.type !== 'directory') {
+          chevron.firstElementChild?.classList.add('invisible');
         }
+        chevron.style.display = 'inline-block';
+        chevron.style.fontSize = '0.7em';
+        span.appendChild(chevron);
 
+        const icon = document.createElement('span');
+        icon.classList.add('me-1');
+        icon.innerHTML =
+          node.type === 'directory'
+            ? '<i class="fa fa-folder"></i>'
+            : '<i class="fa fa-file"></i>';
         span.appendChild(icon);
         span.append(node.name);
         li.appendChild(span);
 
         if (node.type === 'directory') {
+          const ul = document.createElement('ul');
+          ul.classList.add('list-unstyled', 'ps-3');
+          ul.style.display = 'none';
           if (node.children?.length) {
-            const ul = document.createElement('ul');
-            ul.classList.add('list-unstyled', 'ps-3');
-            ul.style.display = 'none';
             build(node.children, ul);
-            li.appendChild(ul);
-
-            span.addEventListener('click', () => {
-              const isOpen = ul.style.display !== 'none';
-              ul.style.display = isOpen ? 'none' : '';
-              if (chevron) {
-                chevron.className = isOpen
-                  ? 'fa fa-chevron-right me-1'
-                  : 'fa fa-chevron-down me-1';
-              }
-              icon.className = isOpen
-                ? 'fa fa-folder me-1'
-                : 'fa fa-folder-open me-1';
-            });
           }
+          li.appendChild(ul);
+
+          span.addEventListener('click', () => {
+            const isOpen = ul.style.display !== 'none';
+            ul.style.display = isOpen ? 'none' : '';
+            chevron.innerHTML = isOpen
+              ? '<i class="fa fa-chevron-right"></i>'
+              : '<i class="fa fa-chevron-down"></i>';
+            icon.innerHTML = isOpen
+              ? '<i class="fa fa-folder"></i>'
+              : '<i class="fa fa-folder-open"></i>';
+          });
         } else {
           li.classList.add('file');
           li.dataset.path = node.path;

--- a/src/browser/mappings/icons.ts
+++ b/src/browser/mappings/icons.ts
@@ -1,6 +1,7 @@
 import { dom, library } from '@fortawesome/fontawesome-svg-core';
 import { faBold } from '@fortawesome/free-solid-svg-icons/faBold';
 import { faCheck } from '@fortawesome/free-solid-svg-icons/faCheck';
+import { faChevronDown } from '@fortawesome/free-solid-svg-icons/faChevronDown';
 import { faChevronRight } from '@fortawesome/free-solid-svg-icons/faChevronRight';
 import { faChevronUp } from '@fortawesome/free-solid-svg-icons/faChevronUp';
 import { faClipboard } from '@fortawesome/free-solid-svg-icons/faClipboard';
@@ -12,6 +13,7 @@ import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons/faExclama
 import { faFileExport } from '@fortawesome/free-solid-svg-icons/faFileExport';
 import { faFile } from '@fortawesome/free-solid-svg-icons/faFile';
 import { faFolder } from '@fortawesome/free-solid-svg-icons/faFolder';
+import { faFolderOpen } from '@fortawesome/free-solid-svg-icons/faFolderOpen';
 import { faItalic } from '@fortawesome/free-solid-svg-icons/faItalic';
 import { faListOl } from '@fortawesome/free-solid-svg-icons/faListOl';
 import { faListUl } from '@fortawesome/free-solid-svg-icons/faListUl';
@@ -26,6 +28,7 @@ import { faTerminal } from '@fortawesome/free-solid-svg-icons/faTerminal';
 library.add(
   faBold,
   faCheck,
+  faChevronDown,
   faChevronRight,
   faChevronUp,
   faClipboard,
@@ -36,6 +39,7 @@ library.add(
   faExclamationCircle,
   faFile,
   faFolder,
+  faFolderOpen,
   faFileExport,
   faItalic,
   faListUl,


### PR DESCRIPTION
## Summary
- prevent folder chevrons from shifting file tree alignment
- show chevron for empty directories and toggle arrow on expand

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a267f34ac83239ba3873dc344202b