### PR TITLE
Optimization: Compute word counts from model instead of scanning DOM

### DIFF
--- a/src/browser/extensions/WordCount.ts
+++ b/src/browser/extensions/WordCount.ts
@@ -1,49 +1,95 @@
-const WordCount = (preview: HTMLElement) => {
-  let count = countWords(getTextInElement(preview));
+/**
+ * Count written words.
+ *
+ * @param value - the editor model content
+ */
+const WordCount = (value: string) => {
+  const text = stripMarkdown(value);
+  let count = countWords(text);
   if (count && count < 0) count = 0;
 
   const wc = document.querySelector('#word-count');
   if (wc) wc.innerHTML = count?.toString() ?? '0';
 };
 
-const CharacterCount = (preview: HTMLElement) => {
-  let count = countCharacters(getTextInElement(preview)) - 1;
+/**
+ * Count written characters.
+ *
+ * @param value - the editor model content
+ */
+const CharacterCount = (value: string) => {
+  const text = stripMarkdown(value);
+  let count = countCharacters(text);
   if (count && count < 0) count = 0;
 
   const cc = document.querySelector('#character-count');
   if (cc) cc.innerHTML = count?.toString() ?? '0';
 };
 
+/**
+ * Strip markdown from the editor model content.
+ *
+ * @param value - the editor model content
+ * @returns the stripped content
+ */
+function stripMarkdown(value: string) {
+  return (
+    value
+      // Remove fenced code blocks (``` or ~~~)
+      .replace(/(^|\n)```[^\n]*\n([\s\S]*?)```/g, (_m, p1, code) => p1 + code)
+      .replace(/(^|\n)~~~[^\n]*\n([\s\S]*?)~~~/g, (_m, p1, code) => p1 + code)
+      // Remove fenced alert blocks (:::)
+      .replace(
+        /(^|\n):::\s*\w+[^\n]*\n([\s\S]*?)\n:::/g,
+        (_m, p1, content) => p1 + content,
+      )
+      // Remove inline code but keep surrounding text
+      .replace(/`[^`]*`/g, ' ')
+      // Remove HTML comments
+      .replace(/<!--[\s\S]*?-->/g, ' ')
+      // Admonition-style blocks ::: ... :::
+      .replace(/(^|\n)::{3,}[\s\S]*?\n::{3,}\s*/g, ' ')
+      // Images: keep alt text
+      .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+      // Links: keep link text
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+      // Reference-style link/image definitions
+      .replace(/^\s*\[[^\]]+]:\s+\S+.*$/gm, ' ')
+      // Footnotes: definitions and inline refs
+      .replace(/^\s*\[\^[^\]]+]:.*$/gm, ' ')
+      .replace(/\[\^[^\]]+]/g, ' ')
+      // Task list checkboxes
+      .replace(/^[ \t]*[-+*]\s+\[[ xX]\]\s+/gm, '')
+      // Unordered/ordered list markers at line start
+      .replace(/^[ \t]*[-+*]\s+/gm, '')
+      .replace(/^[ \t]*\d+\.\s+/gm, '')
+      // Blockquote markers at line start
+      .replace(/^[ \t]*>\s?/gm, '')
+      // Setext heading underlines
+      .replace(/^[ \t]*={2,}\s*$/gm, ' ')
+      .replace(/^[ \t]*-{2,}\s*$/gm, ' ')
+      // Strip HTML tags but keep their inner text
+      .replace(/<\/?[^>\n]+>/g, ' ')
+      // Remove Markdown emphasis delimiters only when they wrap word chars
+      .replace(/(\B\*|\*\B|\B_|_\B|~~)/g, '')
+      // Remove remaining backticks/tilde runs used as formatting
+      .replace(/`{1,3}|~{2,}/g, ' ')
+      // Inline math delimiters: keep contents
+      .replace(/\${1,2}([^$]+)\${1,2}/g, '$1')
+      // Normalize newlines and collapse to single spaces
+      .replace(/\r?\n|\r/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+  );
+}
+
 function countCharacters(str: string) {
   return str.length;
 }
 
 function countWords(str: string) {
-  const words = str.replace(/W+/g, ' ').match(/\S+/g);
-  return words && (words.length || 0);
-}
-
-function getTextInElement(node: any) {
-  let text;
-  if (node.nodeType === 3) {
-    return node.data;
-  }
-
-  text = '';
-
-  if (node.firstChild) {
-    node = node.firstChild;
-    while (true) {
-      text += getTextInElement(node);
-
-      if (!node.nextSibling) {
-        break;
-      }
-      node = node.nextSibling;
-    }
-  }
-
-  return text;
+  const words = str.match(/\S+/g);
+  return words && words.length ? words.length : 0;
 }
 
 export { WordCount, CharacterCount };

--- a/src/browser/lib/Editor.ts
+++ b/src/browser/lib/Editor.ts
@@ -52,7 +52,10 @@ export class Editor {
     this.previewHTMLElement = dom.preview.dom;
     dom.about.version.innerHTML = APP_VERSION;
     this.dispatcher.addEventListener('editor:render', () => {
-      this.render();
+      const value = this.model?.getValue() ?? '';
+      WordCount(value);
+      CharacterCount(value);
+      this.render(value);
     });
   }
 
@@ -115,9 +118,12 @@ export class Editor {
       window.onresize = () => this.model?.layout();
       this.previewHTMLElement.onresize = () => this.model?.layout();
 
+      const value = this.model.getValue();
+      WordCount(value);
+      CharacterCount(value);
       // Render the editor content to preview; also initialises editor
       // extensions.
-      this.render();
+      this.render(value);
 
       if (watch) {
         // Watch the editor for changes, updates the preview and and copntains
@@ -155,14 +161,10 @@ export class Editor {
   /**
    * Render the editor.
    */
-  public render() {
+  public render(value?: string) {
     if (this.model) {
-      this.previewHTMLElement.innerHTML = Markdown.render(
-        this.model.getValue(),
-      );
-
-      WordCount(this.previewHTMLElement);
-      CharacterCount(this.previewHTMLElement);
+      const content = value ?? this.model.getValue();
+      this.previewHTMLElement.innerHTML = Markdown.render(content);
     }
   }
 
@@ -183,8 +185,12 @@ export class Editor {
 
       // Add a small timeout for the render.
       setTimeout(() => {
+        const value = this.model?.getValue() ?? '';
+        WordCount(value);
+        CharacterCount(value);
+
         // Update the rendered content in the preview.
-        this.render();
+        this.render(value);
       }, 150);
     });
 


### PR DESCRIPTION
## What's Changed?

The `WordCount` plugin currently scans the entire preview DOM on each render in order to produce character and word counts, this is highly inefficient and slightly inaccurate.

Refactored the plugin to compute counts based on the model value instead of scanning the DOM, ensuring markdown is stipped beforehand to produce accurate counts.

Tested against various online services such as Grammarly.