### PR TITLE
Optimization: Cache scroll sync line to elements

### DIFF
--- a/src/browser/extensions/ScrollSync.ts
+++ b/src/browser/extensions/ScrollSync.ts
@@ -1,6 +1,7 @@
 import { dom } from '../dom';
 
 let lineElements: { element: HTMLElement; line: number }[] = [];
+let needsRefresh = true;
 
 const cacheLineElements = () => {
   lineElements = [{ element: document.body, line: 0 }];
@@ -29,6 +30,11 @@ const cacheLineElements = () => {
       lineElements.push({ element: node, line });
     }
   }
+  needsRefresh = false;
+};
+
+const invalidateLineElements = () => {
+  needsRefresh = true;
 };
 
 const ScrollSync = async (line: number, preview: HTMLElement) => {
@@ -87,7 +93,13 @@ const getElementsForSourceLine = (targetLine: number) => {
   return { previous };
 };
 
-const getCodeLineElements = () => lineElements;
+const getCodeLineElements = () => {
+  if (needsRefresh) {
+    cacheLineElements();
+  }
+
+  return lineElements;
+};
 
 const getElementBounds = ({ element }: { element: HTMLElement }) => {
   const bounds = element.getBoundingClientRect();
@@ -108,4 +120,4 @@ const getElementBounds = ({ element }: { element: HTMLElement }) => {
   return bounds;
 };
 
-export { ScrollSync, cacheLineElements };
+export { ScrollSync, invalidateLineElements };

--- a/src/browser/lib/Editor.ts
+++ b/src/browser/lib/Editor.ts
@@ -2,7 +2,7 @@ import { editor } from 'monaco-editor/esm/vs/editor/editor.api';
 import { EditorProviders } from '../interfaces/Providers';
 import { EditorDispatcher } from '../events/EditorDispatcher';
 import { CharacterCount, WordCount } from '../extensions/WordCount';
-import { ScrollSync, cacheLineElements } from '../extensions/ScrollSync';
+import { ScrollSync, invalidateLineElements } from '../extensions/ScrollSync';
 import { welcomeMarkdown } from '../assets/intro';
 import { Markdown } from './Markdown';
 import { Exporter } from './Exporter';
@@ -163,7 +163,7 @@ export class Editor {
 
       WordCount(this.previewHTMLElement);
       CharacterCount(this.previewHTMLElement);
-      cacheLineElements();
+      invalidateLineElements();
     }
   }
 


### PR DESCRIPTION
## What's Changed?

Previously scroll-sync repeatedly scanned the DOM and rebuilt the list of line elements on every scroll event causing expensive DOM queries.

This change pre-computes scroll line elements and sets a flag through an exposed helper to refresh the mapping without scanning the DOM on every scroll. Instead, the mapping is rebuilt on the next scroll event.