### PR TITLE
Optimization: Filetree DOM and rendering improvements.

### DIFF
--- a/src/app/lib/AppStorage.ts
+++ b/src/app/lib/AppStorage.ts
@@ -192,15 +192,11 @@ export class AppStorage {
       filtered.map(async (entry) => {
         const full = join(dir, entry.name);
         if (entry.isDirectory()) {
-          const childEntries = await fs.readdir(full, { withFileTypes: true });
-          const hasChildren = childEntries.some(
-            (d) => d.isDirectory() || d.name.endsWith('.md'),
-          );
           return {
             type: 'directory',
             name: entry.name,
             path: full,
-            hasChildren,
+            hasChildren: true,
           };
         }
 

--- a/src/browser/assets/scss/_base.scss
+++ b/src/browser/assets/scss/_base.scss
@@ -16,3 +16,8 @@ body {
   height: 100%;
   padding-bottom: 44px;
 }
+
+#editor-split,
+#preview-split {
+  min-width: 0;
+}

--- a/src/browser/assets/scss/_sidebar.scss
+++ b/src/browser/assets/scss/_sidebar.scss
@@ -1,5 +1,5 @@
 #sidebar {
-  width: 250px;
+  flex: 0 0 auto;
   background-color: #f3f3f3;
   overflow-y: auto;
   height: 100%;

--- a/src/browser/dom.ts
+++ b/src/browser/dom.ts
@@ -154,6 +154,7 @@ export function createDraggableSplitPanels(
   model: editor.IStandaloneCodeEditor,
 ) {
   Split(['#editor-split', '#preview-split'], {
+    minSize: 0,
     onDrag() {
       model.layout();
     },

--- a/src/browser/lib/Bridge.ts
+++ b/src/browser/lib/Bridge.ts
@@ -442,6 +442,14 @@ export class Bridge {
       ul.innerHTML = '';
       ul.dataset.loaded = 'true';
       parent = ul;
+
+      if (tree.length === 0) {
+        li.dataset.hasChildren = 'false';
+        const chevron = li.querySelector(
+          ':scope > span.file-name > span:first-child',
+        );
+        chevron?.firstElementChild?.classList.add('invisible');
+      }
     }
 
     const build = (nodes: any[], parentEl: HTMLElement) => {

--- a/src/browser/views/index.html
+++ b/src/browser/views/index.html
@@ -67,14 +67,14 @@
     <!-- main content -->
     <div id="main" class="border-top d-flex flex-column h-100">
       <ul id="editor-tabs" class="tab-bar"></ul>
-      <div id="app" class="d-flex flex-row flex-grow-1 h-100">
+      <div id="app" class="d-flex flex-row h-100">
         <!-- sidebar -->
         <div id="sidebar" class="p-3">
           <div class="explorer-title">Explorer</div>
           <ul id="file-tree" class="list-unstyled mb-0"></ul>
         </div>
 
-        <div id="wrapper" class="d-flex flex-row w-100">
+        <div id="wrapper" class="d-flex flex-row flex-grow-1 mw-100">
           <!-- editor pane -->
           <div id="editor-split">
             <div id="editor" class="flex-column split-editor"></div>


### PR DESCRIPTION
## What's Changed?

- Introduced a `directoryMap` cache to store `<ul>` elements by directory path for faster lookups during file tree updates
- Changed `buildFileTree` to clear and reuse the cache when rebuilding nodes and to register new directories when created
- Changed `addFileToTree` to use the cached containers for locating parent directories to avoid repeated DOM queries
- Eliminated extra `fs.readdir` calls and added check for actual children when expanding directories
- Changed file tree node creation to batched `DocumentFragment` appended in a single op
- Replaced per-node listeners with a single delegated click handler on the file tree.
- Fixed issues between resizing the file tree explorer, editor and preview.

