### PR TITLE
Refactor Bridge for better modularity

### DIFF
--- a/src/browser/lib/Bridge.ts
+++ b/src/browser/lib/Bridge.ts
@@ -1,54 +1,23 @@
 import { editor } from 'monaco-editor/esm/vs/editor/editor.api';
-import { ContextBridgeAPI, ContextBridgedFile } from '../interfaces/Bridge';
-import { BridgeProviders, ValidModal } from '../interfaces/Providers';
-import { EditorSettings } from '../interfaces/Editor';
+import { ContextBridgeAPI } from '../interfaces/Bridge';
+import { BridgeProviders } from '../interfaces/Providers';
 import { EditorDispatcher } from '../events/EditorDispatcher';
-import { Notify } from './Notify';
+import { EditorSettings } from '../interfaces/Editor';
 import { dom } from '../dom';
-import Swal from 'sweetalert2';
+import { FileManager } from './bridge/files';
+import { FileTree } from './bridge/fileTree';
+import { BridgeSettings } from './bridge/settings';
+import { registerBridgeListeners } from './bridge/listeners';
 
 export class Bridge {
   /** Execution context bridge */
-  private bridge: ContextBridgeAPI;
+  public bridge: ContextBridgeAPI;
 
   /** Editor model instance */
-  private model: editor.IStandaloneCodeEditor;
+  public model: editor.IStandaloneCodeEditor;
 
   /** Editor event dispatcher */
-  private dispatcher: EditorDispatcher;
-
-  /** The current active file */
-  private activeFile: string | null = null;
-
-  /** Flag to determine whether the content has changed */
-  private contentHasChanged: boolean = false;
-
-  /** Map of open file models */
-  private models: Map<string, editor.ITextModel> = new Map();
-
-  /** Map of original contents */
-  private originals: Map<string, string> = new Map();
-
-  /** Map of tab elements */
-  private tabs: Map<string, HTMLAnchorElement> = new Map();
-
-  /** Map of directory <ul> elements */
-  private directoryMap: Map<string, HTMLElement> = new Map();
-
-  /** counter for untitled files */
-  private untitledCounter = 1;
-
-  /** Flag to indicate that a file is being opened */
-  private openingFile = false;
-
-  /** Flag to indicate a new root folder is being opened */
-  private openingFolder = false;
-
-  /** Root path for the current file tree */
-  private treeRoot: string | null = null;
-
-  /** Flag to track file tree listener registration */
-  private fileTreeListenerRegistered = false;
+  public dispatcher: EditorDispatcher;
 
   /** Providers to be accessed through bridge */
   public providers: BridgeProviders = {
@@ -57,15 +26,17 @@ export class Bridge {
     completion: null,
   };
 
+  /** File manager helper */
+  private files: FileManager;
+
+  /** File tree helper */
+  private tree: FileTree;
+
+  /** Settings helper */
+  private settings: BridgeSettings;
+
   /**
    * Create a new mkeditor bridge.
-   *
-   * Responsible for creating a bridge and handling events between
-   * execution contexts.
-   *
-   * @param bridge - the execution bridge
-   * @param model  - the editor model instance
-   * @param dispatcher - the editor event dispatcher
    */
   public constructor(
     bridge: ContextBridgeAPI,
@@ -76,14 +47,26 @@ export class Bridge {
     this.model = model;
     this.dispatcher = dispatcher;
 
-    this.register();
+    this.files = new FileManager(this.bridge, this.model, this.dispatcher);
+    this.tree = new FileTree(this.bridge, (p) => this.openFileFromPath(p));
+    this.settings = new BridgeSettings(this.bridge, this.model);
+
+    registerBridgeListeners(
+      this.bridge,
+      this.model,
+      this.dispatcher,
+      this.providers,
+      this.files,
+      this.tree,
+      this.settings,
+    );
 
     dom.tabs?.addEventListener('dragover', (e) => {
       e.preventDefault();
       if (!dom.tabs) {
         return;
       }
-      const after = this.getDragAfterElement(dom.tabs, e.clientX);
+      const after = this.files.getDragAfterElement(dom.tabs, e.clientX);
       const dragging = dom.tabs.querySelector(
         'li.dragging',
       ) as HTMLLIElement | null;
@@ -102,721 +85,33 @@ export class Bridge {
     });
   }
 
-  /**
-   * Provide access to a provider.
-   *
-   * @param provider - the provider to access
-   * @param instance - the associated provider instance
-   */
+  /** Provide access to a provider */
   public provide<T>(provider: string, instance: T) {
     this.providers[provider] = instance;
   }
 
-  /**
-   * Register bridge events.
-   */
-  public register() {
-    // Set the theme according to the user's system theme
-    this.bridge.receive('from:theme:set', (shouldUseDarkMode: boolean) => {
-      if (shouldUseDarkMode) {
-        this.providers.settings?.setSetting('darkmode', shouldUseDarkMode);
-        this.providers.settings?.setTheme();
-        this.providers.settings?.setUIState();
-      }
-    });
-
-    // Set settings from stored settings file (%HOME%/.mkeditor/settings.json)
-    this.bridge.receive('from:settings:set', (settings: EditorSettings) => {
-      this.loadSettingsFromStorageChannel(settings);
-      this.providers.settings?.setSettings(settings);
-      this.providers.settings?.registerDOMListeners();
-    });
-
-    // Enable new files from outside of the renderer execution context.
-    // Provides access to browser window data and emits it to the ipc channel.
-    this.bridge.receive('from:file:new', (channel: string) => {
-      this.bridge.send('to:title:set', '');
-      this.bridge.send(channel, {
-        content: this.model.getValue(),
-        file: this.activeFile,
-      });
-    });
-
-    // Enable saving files from outside of the renderer execution context.
-    // Provides access to browser window data and emits it to the ipc channel.
-    this.bridge.receive('from:file:save', (channel: string) => {
-      if (this.activeFile && !this.activeFile.startsWith('untitled')) {
-        this.bridge.send(channel, {
-          content: this.model.getValue(),
-          file: this.activeFile,
-        });
-
-        this.originals.set(this.activeFile, this.model.getValue());
-        this.dispatcher.setTrackedContent({
-          content: this.model.getValue(),
-        });
-      } else {
-        this.bridge.send('to:file:saveas', this.model.getValue());
-      }
-    });
-
-    this.bridge.receive('from:file:saveas', (channel: string) => {
-      this.bridge.send(channel, this.model.getValue());
-    });
-
-    // Handle opening folders and constructing file tree
-    this.bridge.receive('from:folder:open', (channel: string) => {
-      this.openingFolder = true;
-      this.bridge.send(channel, true);
-    });
-
-    this.bridge.receive('from:folder:opened', ({ tree, path }) => {
-      if (
-        this.openingFolder ||
-        !this.treeRoot ||
-        !path.startsWith(this.treeRoot)
-      ) {
-        this.treeRoot = path;
-        this.openingFolder = false;
-      }
-      this.buildFileTree(tree, path);
-    });
-
-    // Enable opening files from outside of the renderer execution context.
-    this.bridge.receive('from:file:open', (channel: string) => {
-      this.openingFile = true;
-      this.bridge.send(channel, true);
-    });
-
-    this.bridge.receive(
-      'from:file:opened',
-      ({ content, filename, file }: ContextBridgedFile) => {
-        const path = file || `untitled-${this.untitledCounter++}`;
-        const name = filename || `Untitled ${this.untitledCounter - 1}`;
-        let mdl = this.models.get(path);
-
-        if (
-          !mdl &&
-          !this.openingFile &&
-          this.activeFile &&
-          this.activeFile.startsWith('untitled') &&
-          file
-        ) {
-          mdl = this.models.get(this.activeFile);
-          const tab = this.tabs.get(this.activeFile);
-          if (mdl && tab) {
-            this.models.delete(this.activeFile);
-            this.tabs.delete(this.activeFile);
-            this.originals.delete(this.activeFile);
-
-            tab.textContent = name;
-            const newTab = tab.cloneNode(true) as HTMLAnchorElement;
-            newTab.textContent = name;
-            newTab.addEventListener('click', (e) => {
-              e.preventDefault();
-              this.activateFile(path);
-            });
-            tab.replaceWith(newTab);
-
-            this.models.set(path, mdl);
-            this.tabs.set(path, newTab);
-            this.originals.set(path, content);
-
-            mdl.setValue(content);
-
-            const closeBtn =
-              newTab.nextElementSibling as HTMLButtonElement | null;
-            if (closeBtn) {
-              const newBtn = closeBtn.cloneNode(true) as HTMLButtonElement;
-              newBtn.addEventListener('click', async (e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                await this.closeTab(path);
-              });
-              closeBtn.replaceWith(newBtn);
-            }
-          }
-        }
-
-        // Fallback
-        if (!mdl) {
-          mdl = editor.createModel(content, 'markdown');
-          this.models.set(path, mdl);
-          this.originals.set(path, content);
-          this.addTab(name, path);
-        }
-
-        this.addFileToTree(path);
-        this.activateFile(path, name);
-        this.openingFile = false;
-      },
-    );
-
-    // Enable access to the monaco editor command palette.
-    this.bridge.receive('from:command:palette', (command: string) => {
-      this.model.focus();
-      this.model.trigger(command, 'editor.action.quickCommand', {});
-    });
-
-    // Enable access to the monaco editor shortcuts modal.
-    this.bridge.receive('from:modal:open', (modal: ValidModal) => {
-      const handler = this.providers.commands?.getModal(modal);
-      handler?.toggle();
-    });
-
-    // Enable notifications from the main context.
-    this.bridge.receive(
-      'from:notification:display',
-      (event: { status: string; message: string }) => {
-        Notify.send(event.status, event.message);
-      },
-    );
-  }
-
-  /**
-   * Send a save settings request across the bridge.
-   *
-   * @param settings - the settings to save
-   */
+  /** Send a save settings request across the bridge */
   public saveSettingsToFile(settings: EditorSettings) {
-    this.bridge.send('to:settings:save', { settings });
+    this.settings.saveSettingsToFile(settings);
   }
 
-  /**
-   * Send a save contents request across the bridge.
-   */
+  /** Send a save contents request across the bridge */
   public saveContentToFile() {
-    if (this.activeFile && !this.activeFile.startsWith('untitled')) {
-      this.bridge.send('to:file:save', {
-        content: this.model.getValue(),
-        file: this.activeFile,
-      });
-      this.originals.set(this.activeFile, this.model.getValue());
-      this.dispatcher.setTrackedContent({
-        content: this.model.getValue(),
-      });
-    } else {
-      this.bridge.send('to:file:saveas', this.model.getValue());
-    }
+    this.files.saveContentToFile();
   }
 
-  /**
-   * Send an export preview request across the bridge.
-   *
-   * @param content - the content to export
-   */
+  /** Send an export preview request across the bridge */
   public exportPreviewToFile(content: string) {
-    this.bridge.send('to:html:export', { content });
+    this.files.exportPreviewToFile(content);
   }
 
-  /**
-   * Add a new tab for a file.
-   *
-   * @param name - the file name
-   * @param path - the path of the file
-   */
-  private addTab(name: string, path: string) {
-    const li = document.createElement('li');
-    li.draggable = true;
-    li.dataset.path = path;
-    const a = document.createElement('a');
-    a.href = '#';
-    a.textContent = name;
-    a.draggable = false;
-    a.addEventListener('click', (e) => {
-      e.preventDefault();
-      this.activateFile(path);
-    });
-
-    const close = document.createElement('button');
-    close.type = 'button';
-    close.classList.add('tab-close');
-    close.innerHTML = '&times;';
-    close.draggable = false;
-    close.addEventListener('click', async (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      await this.closeTab(path);
-    });
-
-    li.addEventListener('dragstart', () => {
-      li.classList.add('dragging');
-    });
-
-    li.addEventListener('dragend', () => {
-      li.classList.remove('dragging');
-      this.syncTabOrder();
-    });
-
-    li.appendChild(a);
-    li.appendChild(close);
-    dom.tabs?.appendChild(li);
-    this.tabs.set(path, a);
-  }
-
-  /**
-   * Close a file tree tab.
-   *
-   * @param path - the path of the file to close.
-   * @returns
-   */
-  private async closeTab(path: string) {
-    const mdl = this.models.get(path);
-    if (!mdl) return;
-
-    const original = this.originals.get(path) ?? '';
-    const current = mdl.getValue();
-
-    if (original !== current) {
-      const result = await Swal.fire({
-        customClass: {
-          container: 'unsaved-changes-popup',
-        },
-        title: 'Unsaved changes',
-        text: 'Save changes to your file before closing?',
-        showCancelButton: true,
-        showDenyButton: true,
-        confirmButtonText: 'Save & close',
-        denyButtonText: 'Close without saving',
-        cancelButtonText: 'Cancel',
-      });
-
-      if (result.isConfirmed) {
-        if (path.startsWith('untitled')) {
-          this.bridge.send('to:file:saveas', current);
-        } else {
-          this.bridge.send('to:file:save', {
-            content: current,
-            file: path,
-            openFile: false,
-          });
-        }
-      } else if (!result.isDenied) {
-        return;
-      }
-    }
-
-    mdl.dispose();
-    this.models.delete(path);
-    this.originals.delete(path);
-
-    const tab = this.tabs.get(path);
-    tab?.parentElement?.remove();
-    this.tabs.delete(path);
-
-    if (this.activeFile === path) {
-      this.activeFile = null;
-      const next = this.tabs.keys().next();
-      if (!next.done) {
-        const nextPath = next.value;
-        const nextTab = this.tabs.get(nextPath);
-        this.activateFile(nextPath, nextTab?.textContent || undefined);
-      } else {
-        const newPath = `untitled-${this.untitledCounter++}`;
-        const model = editor.createModel('', 'markdown');
-        this.models.set(newPath, model);
-        this.originals.set(newPath, '');
-        this.addTab(`Untitled ${this.untitledCounter - 1}`, newPath);
-        this.activateFile(newPath, `Untitled ${this.untitledCounter - 1}`);
-      }
-    }
-  }
-
-  /**
-   * Synchronize the order of file tabs.
-   *
-   * @returns
-   */
-  private syncTabOrder() {
-    if (!dom.tabs) return;
-    const newMap: Map<string, HTMLAnchorElement> = new Map();
-    dom.tabs.querySelectorAll('li').forEach((li) => {
-      const path = (li as HTMLLIElement).dataset.path;
-      if (!path) return;
-      const anchor = this.tabs.get(path);
-      if (anchor) newMap.set(path, anchor);
-    });
-    this.tabs = newMap;
-  }
-
-  /**
-   * Get the next element from the drag.
-   *
-   * @param container - the tabs container
-   * @param x - the next tab offset
-   * @returns
-   */
-  private getDragAfterElement(container: HTMLElement, x: number) {
-    const elements = Array.from(
-      container.querySelectorAll('li:not(.dragging)'),
-    ) as HTMLElement[];
-    let closest: { offset: number; element: HTMLElement | null } = {
-      offset: Number.NEGATIVE_INFINITY,
-      element: null,
-    };
-    for (const child of elements) {
-      const box = child.getBoundingClientRect();
-      const offset = x - box.left - box.width / 2;
-      if (offset < 0 && offset > closest.offset) {
-        closest = { offset, element: child };
-      }
-    }
-    return closest.element;
-  }
-
-  /**
-   * Activate a file after opening.
-   *
-   * @param path - the path of the file to activate
-   * @param name - the file name
-   * @returns
-   */
-  private activateFile(path: string, name?: string) {
-    const mdl = this.models.get(path);
-    if (!mdl) {
-      return;
-    }
-
-    this.activeFile = path;
-    this.model.setModel(mdl);
-    const filename = name || path.split(/[\\/]/).pop() || '';
-    dom.meta.file.active.innerText = filename;
-
-    const original = this.originals.get(path) ?? '';
-    const current = this.model.getValue();
-
-    this.dispatcher.setTrackedContent({ content: original });
-    this.trackEditorStateBetweenExecutionContext(original !== current);
-
-    this.tabs.forEach((tab, p) => {
-      const li = tab.parentElement as HTMLElement;
-      if (p === path) {
-        li.classList.add('active');
-      } else li.classList.remove('active');
-    });
-
-    if (dom.filetree) {
-      dom.filetree.querySelectorAll('li.file .file-name').forEach((el) => {
-        const li = (el as HTMLElement).parentElement as HTMLElement;
-        if (li.dataset.path === path)
-          (el as HTMLElement).classList.add('active');
-        else (el as HTMLElement).classList.remove('active');
-      });
-    }
-
-    this.dispatcher.render();
-    this.model.focus();
-
-    this.bridge.send('to:title:set', filename === '' ? 'New File' : filename);
-  }
-
-  /**
-   * Build the file explorer tree.
-   *
-   * @param tree - build the file tree
-   * @param parentPath - recursive parent path
-   * @returns
-   */
-  private buildFileTree(tree: any[], parentPath: string) {
-    if (!dom.filetree || !Array.isArray(tree)) {
-      return;
-    }
-
-    if (!this.fileTreeListenerRegistered) {
-      dom.filetree.addEventListener('click', this.handleFileTreeClick);
-      this.fileTreeListenerRegistered = true;
-    }
-
-    let parent: HTMLElement;
-    if (!this.treeRoot || parentPath === this.treeRoot) {
-      dom.filetree.innerHTML = '';
-      parent = dom.filetree;
-      this.directoryMap.clear();
-      this.directoryMap.set(parentPath, dom.filetree);
-    } else {
-      const ul = this.directoryMap.get(parentPath);
-      if (!ul) {
-        return;
-      }
-      ul.innerHTML = '';
-      ul.dataset.loaded = 'true';
-      parent = ul;
-
-      const li = ul.parentElement as HTMLElement | null;
-      if (tree.length === 0 && li) {
-        li.dataset.hasChildren = 'false';
-        const chevron = li.querySelector(
-          ':scope > span.file-name > span:first-child',
-        );
-        chevron?.firstElementChild?.classList.add('invisible');
-      }
-    }
-
-    const build = (nodes: any[], parentEl: HTMLElement) => {
-      const validNodes = nodes.filter((n) => {
-        if (
-          n &&
-          (n.type === 'directory' || n.type === 'file') &&
-          typeof n.name == 'string' &&
-          typeof n.path === 'string'
-        ) {
-          return n;
-        }
-      });
-
-      const sorted = [...validNodes].sort((a, b) => {
-        if (a.type === b.type) {
-          return a.name.localeCompare(b.name, undefined, {
-            sensitivity: 'base',
-          });
-        }
-        return a.type === 'directory' ? -1 : 1;
-      });
-
-      const fragment = document.createDocumentFragment();
-      sorted.forEach((node) => {
-        const li = document.createElement('li');
-        li.classList.add('ft-node', node.type);
-
-        const span = document.createElement('span');
-        span.classList.add('file-name');
-
-        const chevron = document.createElement('span');
-        chevron.classList.add('me-1');
-        chevron.innerHTML = '<i class="fa fa-chevron-right"></i>';
-        if (node.type !== 'directory' || !node.hasChildren) {
-          chevron.firstElementChild?.classList.add('invisible');
-        }
-        chevron.style.display = 'inline-block';
-        chevron.style.fontSize = '0.7em';
-        span.appendChild(chevron);
-
-        const icon = document.createElement('span');
-        icon.classList.add('me-1');
-        icon.innerHTML =
-          node.type === 'directory'
-            ? '<i class="fa fa-folder"></i>'
-            : '<i class="fa fa-file"></i>';
-        span.appendChild(icon);
-        span.append(node.name);
-        li.appendChild(span);
-
-        if (node.type === 'directory') {
-          li.dataset.path = node.path;
-          li.dataset.hasChildren = node.hasChildren ? 'true' : 'false';
-          const ul = document.createElement('ul');
-          ul.classList.add('list-unstyled', 'ps-3');
-          ul.style.display = 'none';
-          li.appendChild(ul);
-          this.directoryMap.set(node.path, ul);
-        } else {
-          li.classList.add('file');
-          li.dataset.path = node.path;
-        }
-        fragment.appendChild(li);
-      });
-      parentEl.appendChild(fragment);
-    };
-
-    build(tree, parent);
-  }
-
-  /**
-   * Handle file tree click events.
-   *
-   * @param e - the click event
-   * @returns
-   */
-  private handleFileTreeClick = (e: MouseEvent) => {
-    const target = e.target as HTMLElement;
-    const span = target.closest('span.file-name');
-    if (!span) {
-      return;
-    }
-
-    const li = span.parentElement as HTMLElement;
-    if (!li) {
-      return;
-    }
-
-    if (li.classList.contains('directory')) {
-      const ul = li.querySelector(':scope > ul') as HTMLElement | null;
-      if (!ul) {
-        return;
-      }
-
-      const chevron = span.firstElementChild as HTMLElement;
-      const icon = chevron?.nextElementSibling as HTMLElement;
-      const isOpen = ul.style.display !== 'none';
-
-      if (isOpen) {
-        ul.style.display = 'none';
-        chevron.innerHTML = '<i class="fa fa-chevron-right"></i>';
-        icon.innerHTML = '<i class="fa fa-folder"></i>';
-      } else {
-        ul.style.display = '';
-        chevron.innerHTML = '<i class="fa fa-chevron-down"></i>';
-        icon.innerHTML = '<i class="fa fa-folder-open"></i>';
-        if (
-          !ul.dataset.loaded &&
-          li.dataset.hasChildren === 'true' &&
-          li.dataset.path
-        ) {
-          this.bridge.send('to:file:openpath', { path: li.dataset.path });
-        }
-      }
-    } else if (li.classList.contains('file') && li.dataset.path) {
-      e.preventDefault();
-      this.openFileFromPath(li.dataset.path);
-    }
-  };
-
-  /**
-   * Add a file to the file explorer tree.
-   *
-   * @param path - the path of the file
-   * @returns
-   */
-  private addFileToTree(path: string) {
-    if (!dom.filetree || !this.treeRoot) {
-      return;
-    }
-
-    if (!path.startsWith(this.treeRoot)) {
-      return;
-    }
-
-    const sep = this.treeRoot.includes('\\') ? '\\' : '/';
-    const segments = path.split(/[/\\]/);
-    const rootSegments = this.treeRoot.split(/[/\\]/);
-    const rel = segments.slice(rootSegments.length);
-
-    let currentPath = this.treeRoot;
-    let parentUl = this.directoryMap.get(currentPath) || dom.filetree;
-    if (!parentUl) {
-      return;
-    }
-
-    for (let i = 0; i < rel.length - 1; i++) {
-      const dir = rel[i];
-      currentPath += sep + dir;
-
-      const ul = this.directoryMap.get(currentPath);
-      if (!ul) {
-        return;
-      }
-
-      if (ul.style.display === 'none') {
-        const span = ul.previousElementSibling as HTMLElement;
-        span?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      }
-
-      parentUl = ul;
-    }
-
-    const fileName = rel[rel.length - 1];
-    const existing = Array.from(
-      parentUl.querySelectorAll(':scope > li.file'),
-    ).find((el) => (el as HTMLElement).dataset.path === path);
-    if (existing) {
-      return;
-    }
-
-    const li = document.createElement('li');
-    li.classList.add('ft-node', 'file');
-    li.dataset.path = path;
-
-    const span = document.createElement('span');
-    span.classList.add('file-name');
-
-    const chevron = document.createElement('span');
-    chevron.classList.add('me-1');
-    chevron.innerHTML = '<i class="fa fa-chevron-right"></i>';
-    chevron.firstElementChild?.classList.add('invisible');
-    chevron.style.display = 'inline-block';
-    chevron.style.fontSize = '0.7em';
-    span.appendChild(chevron);
-
-    const icon = document.createElement('span');
-    icon.classList.add('me-1');
-    icon.innerHTML = '<i class="fa fa-file"></i>';
-    span.appendChild(icon);
-    span.append(fileName);
-
-    li.appendChild(span);
-
-    const fileNodes = Array.from(
-      parentUl.querySelectorAll(':scope > li.file'),
-    ) as HTMLElement[];
-    const before = fileNodes.find((el) => {
-      const nameEl = el.querySelector(':scope > span.file-name');
-      const name = nameEl?.textContent?.trim() || '';
-      return (
-        fileName.localeCompare(name, undefined, { sensitivity: 'base' }) < 0
-      );
-    });
-    if (before) {
-      parentUl.insertBefore(li, before);
-    } else {
-      parentUl.appendChild(li);
-    }
-  }
-
-  /**
-   * Open a file from a given path.
-   *
-   * @param path - the file path to open
-   */
+  /** Open a file from a given path */
   public openFileFromPath(path: string) {
-    this.openingFile = true;
-
-    if (this.models.has(path)) {
-      this.activateFile(path);
-      this.openingFile = false;
-      return;
-    }
-
-    if (this.contentHasChanged && this.activeFile !== path) {
-      // Update the tracked content so the existing file retains its unsaved state
-      this.dispatcher.setTrackedContent({
-        content: this.model.getValue(),
-      });
-    }
-
-    this.bridge.send('to:file:openpath', { path });
+    this.files.openFileFromPath(path);
   }
 
-  /**
-   * Track the editor state between both exection contexts.
-   *
-   * @param hasChanged - whether the editor content has changed
-   */
+  /** Track the editor state between both execution contexts */
   public trackEditorStateBetweenExecutionContext(hasChanged: boolean) {
-    this.bridge.send('to:editor:state', hasChanged);
-    this.contentHasChanged = hasChanged;
-  }
-
-  /**
-   * private method to load settings for the editor model, used by the
-   * from:settings:set bridge channel receiver.
-   *
-   * @param settings - the editor settings to load
-   */
-  private loadSettingsFromStorageChannel(settings: EditorSettings) {
-    this.model.updateOptions({
-      autoIndent: settings.autoindent ? 'advanced' : 'none',
-    });
-
-    this.model.updateOptions({
-      wordWrap: settings.wordwrap ? 'on' : 'off',
-    });
-
-    this.model.updateOptions({
-      renderWhitespace: settings.whitespace ? 'all' : 'none',
-    });
-
-    this.model.updateOptions({
-      minimap: { enabled: settings.minimap },
-    });
+    this.files.trackEditorStateBetweenExecutionContext(hasChanged);
   }
 }

--- a/src/browser/lib/Markdown.ts
+++ b/src/browser/lib/Markdown.ts
@@ -1,14 +1,14 @@
 import hljs from 'highlight.js/lib/core';
 
 // Supported languages for markdown codeblocks
-import c from 'highlight.js/lib/languages/c.js';
-import cpp from 'highlight.js/lib/languages/cpp.js';
+import c from 'highlight.js/lib/languages/c';
+import cpp from 'highlight.js/lib/languages/cpp';
 import csharp from 'highlight.js/lib/languages/csharp';
 import javascript from 'highlight.js/lib/languages/javascript';
 import json from 'highlight.js/lib/languages/json';
 import php from 'highlight.js/lib/languages/php';
 import python from 'highlight.js/lib/languages/python';
-import rust from 'highlight.js/lib/languages/rust.js';
+import rust from 'highlight.js/lib/languages/rust';
 import shell from 'highlight.js/lib/languages/shell';
 import sql from 'highlight.js/lib/languages/sql';
 import typescript from 'highlight.js/lib/languages/typescript';

--- a/src/browser/lib/bridge/fileTree.ts
+++ b/src/browser/lib/bridge/fileTree.ts
@@ -1,0 +1,260 @@
+import { ContextBridgeAPI } from '../../interfaces/Bridge';
+import { dom } from '../../dom';
+
+/**
+ * Handle the file explorer tree.
+ */
+export class FileTree {
+  /** Root path for the current file tree */
+  public treeRoot: string | null = null;
+
+  /** Map of directory <ul> elements */
+  public directoryMap: Map<string, HTMLElement> = new Map();
+
+  /** Flag to track file tree listener registration */
+  public fileTreeListenerRegistered = false;
+
+  /** Flag to indicate a new root folder is being opened */
+  public openingFolder = false;
+
+  constructor(
+    private bridge: ContextBridgeAPI,
+    private openFileFromPath: (path: string) => void,
+  ) {}
+
+  /** Build the file explorer tree */
+  public buildFileTree(tree: any[], parentPath: string) {
+    if (!dom.filetree || !Array.isArray(tree)) {
+      return;
+    }
+
+    if (!this.fileTreeListenerRegistered) {
+      dom.filetree.addEventListener('click', this.handleFileTreeClick);
+      this.fileTreeListenerRegistered = true;
+    }
+
+    let parent: HTMLElement;
+    if (!this.treeRoot || parentPath === this.treeRoot) {
+      dom.filetree.innerHTML = '';
+      parent = dom.filetree;
+      this.directoryMap.clear();
+      this.directoryMap.set(parentPath, dom.filetree);
+    } else {
+      const ul = this.directoryMap.get(parentPath);
+      if (!ul) {
+        return;
+      }
+      ul.innerHTML = '';
+      ul.dataset.loaded = 'true';
+      parent = ul;
+
+      const li = ul.parentElement as HTMLElement | null;
+      if (tree.length === 0 && li) {
+        li.dataset.hasChildren = 'false';
+        const chevron = li.querySelector(
+          ':scope > span.file-name > span:first-child',
+        );
+        chevron?.firstElementChild?.classList.add('invisible');
+      }
+    }
+
+    const build = (nodes: any[], parentEl: HTMLElement) => {
+      const validNodes = nodes.filter((n) => {
+        if (
+          n &&
+          (n.type === 'directory' || n.type === 'file') &&
+          typeof n.name == 'string' &&
+          typeof n.path === 'string'
+        ) {
+          return n;
+        }
+      });
+
+      const sorted = [...validNodes].sort((a, b) => {
+        if (a.type === b.type) {
+          return a.name.localeCompare(b.name, undefined, {
+            sensitivity: 'base',
+          });
+        }
+        return a.type === 'directory' ? -1 : 1;
+      });
+
+      const fragment = document.createDocumentFragment();
+      sorted.forEach((node) => {
+        const li = document.createElement('li');
+        li.classList.add('ft-node', node.type);
+
+        const span = document.createElement('span');
+        span.classList.add('file-name');
+
+        const chevron = document.createElement('span');
+        chevron.classList.add('me-1');
+        chevron.innerHTML = '<i class="fa fa-chevron-right"></i>';
+        if (node.type !== 'directory' || !node.hasChildren) {
+          chevron.firstElementChild?.classList.add('invisible');
+        }
+        chevron.style.display = 'inline-block';
+        chevron.style.fontSize = '0.7em';
+        span.appendChild(chevron);
+
+        const icon = document.createElement('span');
+        icon.classList.add('me-1');
+        icon.innerHTML =
+          node.type === 'directory'
+            ? '<i class="fa fa-folder"></i>'
+            : '<i class="fa fa-file"></i>';
+        span.appendChild(icon);
+        span.append(node.name);
+        li.appendChild(span);
+
+        if (node.type === 'directory') {
+          li.dataset.path = node.path;
+          li.dataset.hasChildren = node.hasChildren ? 'true' : 'false';
+          const ul = document.createElement('ul');
+          ul.classList.add('list-unstyled', 'ps-3');
+          ul.style.display = 'none';
+          li.appendChild(ul);
+          this.directoryMap.set(node.path, ul);
+        } else {
+          li.classList.add('file');
+          li.dataset.path = node.path;
+        }
+        fragment.appendChild(li);
+      });
+      parentEl.appendChild(fragment);
+    };
+
+    build(tree, parent);
+  }
+
+  /** Handle file tree click events */
+  private handleFileTreeClick = (e: MouseEvent) => {
+    const target = e.target as HTMLElement;
+    const span = target.closest('span.file-name');
+    if (!span) {
+      return;
+    }
+
+    const li = span.parentElement as HTMLElement;
+    if (!li) {
+      return;
+    }
+
+    if (li.classList.contains('directory')) {
+      const ul = li.querySelector(':scope > ul') as HTMLElement | null;
+      if (!ul) {
+        return;
+      }
+
+      const chevron = span.firstElementChild as HTMLElement;
+      const icon = chevron?.nextElementSibling as HTMLElement;
+      const isOpen = ul.style.display !== 'none';
+
+      if (isOpen) {
+        ul.style.display = 'none';
+        chevron.innerHTML = '<i class="fa fa-chevron-right"></i>';
+        icon.innerHTML = '<i class="fa fa-folder"></i>';
+      } else {
+        ul.style.display = '';
+        chevron.innerHTML = '<i class="fa fa-chevron-down"></i>';
+        icon.innerHTML = '<i class="fa fa-folder-open"></i>';
+        if (
+          !ul.dataset.loaded &&
+          li.dataset.hasChildren === 'true' &&
+          li.dataset.path
+        ) {
+          this.bridge.send('to:file:openpath', { path: li.dataset.path });
+        }
+      }
+    } else if (li.classList.contains('file') && li.dataset.path) {
+      e.preventDefault();
+      this.openFileFromPath(li.dataset.path);
+    }
+  };
+
+  /** Add a file to the file explorer tree */
+  public addFileToTree(path: string) {
+    if (!dom.filetree || !this.treeRoot) {
+      return;
+    }
+
+    if (!path.startsWith(this.treeRoot)) {
+      return;
+    }
+
+    const sep = this.treeRoot.includes('\\') ? '\\' : '/';
+    const segments = path.split(/[/\\]/);
+    const rootSegments = this.treeRoot.split(/[/\\]/);
+    const rel = segments.slice(rootSegments.length);
+
+    let currentPath = this.treeRoot;
+    let parentUl = this.directoryMap.get(currentPath) || dom.filetree;
+    if (!parentUl) {
+      return;
+    }
+
+    for (let i = 0; i < rel.length - 1; i++) {
+      const dir = rel[i];
+      currentPath += sep + dir;
+
+      const ul = this.directoryMap.get(currentPath);
+      if (!ul) {
+        return;
+      }
+
+      if (ul.style.display === 'none') {
+        const span = ul.previousElementSibling as HTMLElement;
+        span?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      }
+
+      parentUl = ul;
+    }
+
+    const fileName = rel[rel.length - 1];
+    const existing = Array.from(
+      parentUl.querySelectorAll(':scope > li.file'),
+    ).find((el) => (el as HTMLElement).dataset.path === path);
+    if (existing) {
+      return;
+    }
+
+    const li = document.createElement('li');
+    li.classList.add('ft-node', 'file');
+    li.dataset.path = path;
+
+    const span = document.createElement('span');
+    span.classList.add('file-name');
+
+    const chevron = document.createElement('span');
+    chevron.classList.add('me-1');
+    chevron.innerHTML = '<i class="fa fa-chevron-right"></i>';
+    chevron.firstElementChild?.classList.add('invisible');
+    chevron.style.display = 'inline-block';
+    chevron.style.fontSize = '0.7em';
+    span.appendChild(chevron);
+
+    const icon = document.createElement('span');
+    icon.classList.add('me-1');
+    icon.innerHTML = '<i class="fa fa-file"></i>';
+    span.appendChild(icon);
+    span.append(fileName);
+
+    li.appendChild(span);
+
+    const fileNodes = Array.from(
+      parentUl.querySelectorAll(':scope > li.file'),
+    ) as HTMLElement[];
+    const before = fileNodes.find((el) => {
+      const nameEl = el.querySelector(':scope > span.file-name');
+      const name = nameEl?.textContent?.trim() || '';
+      return (
+        fileName.localeCompare(name, undefined, { sensitivity: 'base' }) < 0
+      );
+    });
+    if (before) {
+      parentUl.insertBefore(li, before);
+    } else {
+      parentUl.appendChild(li);
+    }
+  }
+}

--- a/src/browser/lib/bridge/files.ts
+++ b/src/browser/lib/bridge/files.ts
@@ -1,0 +1,256 @@
+import { editor } from 'monaco-editor/esm/vs/editor/editor.api';
+import { ContextBridgeAPI } from '../../interfaces/Bridge';
+import { EditorDispatcher } from '../../events/EditorDispatcher';
+import Swal from 'sweetalert2';
+import { dom } from '../../dom';
+
+/**
+ * Handle editor files, models and tabs.
+ */
+export class FileManager {
+  /** The current active file */
+  public activeFile: string | null = null;
+
+  /** Flag to determine whether the content has changed */
+  public contentHasChanged = false;
+
+  /** Map of open file models */
+  public models: Map<string, editor.ITextModel> = new Map();
+
+  /** Map of original contents */
+  public originals: Map<string, string> = new Map();
+
+  /** Map of tab elements */
+  public tabs: Map<string, HTMLAnchorElement> = new Map();
+
+  /** counter for untitled files */
+  public untitledCounter = 1;
+
+  /** Flag to indicate that a file is being opened */
+  public openingFile = false;
+
+  constructor(
+    private bridge: ContextBridgeAPI,
+    private model: editor.IStandaloneCodeEditor,
+    private dispatcher: EditorDispatcher,
+  ) {}
+
+  /** Add a new tab for a file */
+  public addTab(name: string, path: string) {
+    const li = document.createElement('li');
+    li.draggable = true;
+    li.dataset.path = path;
+    const a = document.createElement('a');
+    a.href = '#';
+    a.textContent = name;
+    a.draggable = false;
+    a.addEventListener('click', (e) => {
+      e.preventDefault();
+      this.activateFile(path);
+    });
+
+    const close = document.createElement('button');
+    close.type = 'button';
+    close.classList.add('tab-close');
+    close.innerHTML = '&times;';
+    close.draggable = false;
+    close.addEventListener('click', async (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      await this.closeTab(path);
+    });
+
+    li.addEventListener('dragstart', () => {
+      li.classList.add('dragging');
+    });
+
+    li.addEventListener('dragend', () => {
+      li.classList.remove('dragging');
+      this.syncTabOrder();
+    });
+
+    li.appendChild(a);
+    li.appendChild(close);
+    dom.tabs?.appendChild(li);
+    this.tabs.set(path, a);
+  }
+
+  /** Close a file tree tab */
+  public async closeTab(path: string) {
+    const mdl = this.models.get(path);
+    if (!mdl) return;
+
+    const original = this.originals.get(path) ?? '';
+    const current = mdl.getValue();
+
+    if (original !== current) {
+      const result = await Swal.fire({
+        customClass: { container: 'unsaved-changes-popup' },
+        title: 'Unsaved changes',
+        text: 'Save changes to your file before closing?',
+        showCancelButton: true,
+        showDenyButton: true,
+        confirmButtonText: 'Save & close',
+        denyButtonText: 'Close without saving',
+        cancelButtonText: 'Cancel',
+      });
+
+      if (result.isConfirmed) {
+        if (path.startsWith('untitled')) {
+          this.bridge.send('to:file:saveas', current);
+        } else {
+          this.bridge.send('to:file:save', {
+            content: current,
+            file: path,
+            openFile: false,
+          });
+        }
+      } else if (!result.isDenied) {
+        return;
+      }
+    }
+
+    mdl.dispose();
+    this.models.delete(path);
+    this.originals.delete(path);
+
+    const tab = this.tabs.get(path);
+    tab?.parentElement?.remove();
+    this.tabs.delete(path);
+
+    if (this.activeFile === path) {
+      this.activeFile = null;
+      const next = this.tabs.keys().next();
+      if (!next.done) {
+        const nextPath = next.value;
+        const nextTab = this.tabs.get(nextPath);
+        this.activateFile(nextPath, nextTab?.textContent || undefined);
+      } else {
+        const newPath = `untitled-${this.untitledCounter++}`;
+        const model = editor.createModel('', 'markdown');
+        this.models.set(newPath, model);
+        this.originals.set(newPath, '');
+        this.addTab(`Untitled ${this.untitledCounter - 1}`, newPath);
+        this.activateFile(newPath, `Untitled ${this.untitledCounter - 1}`);
+      }
+    }
+  }
+
+  /** Synchronize the order of file tabs */
+  private syncTabOrder() {
+    if (!dom.tabs) return;
+    const newMap: Map<string, HTMLAnchorElement> = new Map();
+    dom.tabs.querySelectorAll('li').forEach((li) => {
+      const path = (li as HTMLLIElement).dataset.path;
+      if (!path) return;
+      const anchor = this.tabs.get(path);
+      if (anchor) newMap.set(path, anchor);
+    });
+    this.tabs = newMap;
+  }
+
+  /** Get the next element from the drag */
+  public getDragAfterElement(container: HTMLElement, x: number) {
+    const elements = Array.from(
+      container.querySelectorAll('li:not(.dragging)'),
+    ) as HTMLElement[];
+    let closest: { offset: number; element: HTMLElement | null } = {
+      offset: Number.NEGATIVE_INFINITY,
+      element: null,
+    };
+    for (const child of elements) {
+      const box = child.getBoundingClientRect();
+      const offset = x - box.left - box.width / 2;
+      if (offset < 0 && offset > closest.offset) {
+        closest = { offset, element: child };
+      }
+    }
+    return closest.element;
+  }
+
+  /** Activate a file after opening */
+  public activateFile(path: string, name?: string) {
+    const mdl = this.models.get(path);
+    if (!mdl) {
+      return;
+    }
+
+    this.activeFile = path;
+    this.model.setModel(mdl);
+    const filename = name || path.split(/[\\/]/).pop() || '';
+    dom.meta.file.active.innerText = filename;
+
+    const original = this.originals.get(path) ?? '';
+    const current = this.model.getValue();
+
+    this.dispatcher.setTrackedContent({ content: original });
+    this.trackEditorStateBetweenExecutionContext(original !== current);
+
+    this.tabs.forEach((tab, p) => {
+      const li = tab.parentElement as HTMLElement;
+      if (p === path) {
+        li.classList.add('active');
+      } else li.classList.remove('active');
+    });
+
+    if (dom.filetree) {
+      dom.filetree.querySelectorAll('li.file .file-name').forEach((el) => {
+        const li = (el as HTMLElement).parentElement as HTMLElement;
+        if (li.dataset.path === path)
+          (el as HTMLElement).classList.add('active');
+        else (el as HTMLElement).classList.remove('active');
+      });
+    }
+
+    this.dispatcher.render();
+    this.model.focus();
+
+    this.bridge.send('to:title:set', filename === '' ? 'New File' : filename);
+  }
+
+  /** Open a file from a given path */
+  public openFileFromPath(path: string) {
+    this.openingFile = true;
+
+    if (this.models.has(path)) {
+      this.activateFile(path);
+      this.openingFile = false;
+      return;
+    }
+
+    if (this.contentHasChanged && this.activeFile !== path) {
+      this.dispatcher.setTrackedContent({
+        content: this.model.getValue(),
+      });
+    }
+
+    this.bridge.send('to:file:openpath', { path });
+  }
+
+  /** Track the editor state between both execution contexts */
+  public trackEditorStateBetweenExecutionContext(hasChanged: boolean) {
+    this.bridge.send('to:editor:state', hasChanged);
+    this.contentHasChanged = hasChanged;
+  }
+
+  /** Send a save contents request across the bridge */
+  public saveContentToFile() {
+    if (this.activeFile && !this.activeFile.startsWith('untitled')) {
+      this.bridge.send('to:file:save', {
+        content: this.model.getValue(),
+        file: this.activeFile,
+      });
+      this.originals.set(this.activeFile, this.model.getValue());
+      this.dispatcher.setTrackedContent({
+        content: this.model.getValue(),
+      });
+    } else {
+      this.bridge.send('to:file:saveas', this.model.getValue());
+    }
+  }
+
+  /** Send an export preview request across the bridge */
+  public exportPreviewToFile(content: string) {
+    this.bridge.send('to:html:export', { content });
+  }
+}

--- a/src/browser/lib/bridge/listeners.ts
+++ b/src/browser/lib/bridge/listeners.ts
@@ -1,0 +1,176 @@
+import { editor } from 'monaco-editor/esm/vs/editor/editor.api';
+import { ContextBridgeAPI, ContextBridgedFile } from '../../interfaces/Bridge';
+import { BridgeProviders, ValidModal } from '../../interfaces/Providers';
+import { EditorSettings } from '../../interfaces/Editor';
+import { EditorDispatcher } from '../../events/EditorDispatcher';
+import { Notify } from '../Notify';
+import { FileManager } from './files';
+import { FileTree } from './fileTree';
+import { BridgeSettings } from './settings';
+
+/**
+ * Register bridge channel listeners.
+ */
+export function registerBridgeListeners(
+  bridge: ContextBridgeAPI,
+  model: editor.IStandaloneCodeEditor,
+  dispatcher: EditorDispatcher,
+  providers: BridgeProviders,
+  files: FileManager,
+  tree: FileTree,
+  settings: BridgeSettings,
+) {
+  // Set the theme according to the user's system theme
+  bridge.receive('from:theme:set', (shouldUseDarkMode: boolean) => {
+    if (shouldUseDarkMode) {
+      providers.settings?.setSetting('darkmode', shouldUseDarkMode);
+      providers.settings?.setTheme();
+      providers.settings?.setUIState();
+    }
+  });
+
+  // Set settings from stored settings file (%HOME%/.mkeditor/settings.json)
+  bridge.receive('from:settings:set', (s: EditorSettings) => {
+    settings.loadSettingsFromStorageChannel(s);
+    providers.settings?.setSettings(s);
+    providers.settings?.registerDOMListeners();
+  });
+
+  // Enable new files from outside of the renderer execution context.
+  bridge.receive('from:file:new', (channel: string) => {
+    bridge.send('to:title:set', '');
+    bridge.send(channel, {
+      content: model.getValue(),
+      file: files.activeFile,
+    });
+  });
+
+  // Enable saving files from outside of the renderer execution context.
+  bridge.receive('from:file:save', (channel: string) => {
+    if (files.activeFile && !files.activeFile.startsWith('untitled')) {
+      bridge.send(channel, {
+        content: model.getValue(),
+        file: files.activeFile,
+      });
+
+      files.originals.set(files.activeFile, model.getValue());
+      dispatcher.setTrackedContent({
+        content: model.getValue(),
+      });
+    } else {
+      bridge.send('to:file:saveas', model.getValue());
+    }
+  });
+
+  bridge.receive('from:file:saveas', (channel: string) => {
+    bridge.send(channel, model.getValue());
+  });
+
+  // Handle opening folders and constructing file tree
+  bridge.receive('from:folder:open', (channel: string) => {
+    tree.openingFolder = true;
+    bridge.send(channel, true);
+  });
+
+  bridge.receive('from:folder:opened', ({ tree: t, path }) => {
+    if (
+      tree.openingFolder ||
+      !tree.treeRoot ||
+      !path.startsWith(tree.treeRoot)
+    ) {
+      tree.treeRoot = path;
+      tree.openingFolder = false;
+    }
+    tree.buildFileTree(t, path);
+  });
+
+  // Enable opening files from outside of the renderer execution context.
+  bridge.receive('from:file:open', (channel: string) => {
+    files.openingFile = true;
+    bridge.send(channel, true);
+  });
+
+  bridge.receive(
+    'from:file:opened',
+    ({ content, filename, file }: ContextBridgedFile) => {
+      const path = file || `untitled-${files.untitledCounter++}`;
+      const name = filename || `Untitled ${files.untitledCounter - 1}`;
+      let mdl = files.models.get(path);
+
+      if (
+        !mdl &&
+        !files.openingFile &&
+        files.activeFile &&
+        files.activeFile.startsWith('untitled') &&
+        file
+      ) {
+        mdl = files.models.get(files.activeFile);
+        const tab = files.tabs.get(files.activeFile);
+        if (mdl && tab) {
+          files.models.delete(files.activeFile);
+          files.tabs.delete(files.activeFile);
+          files.originals.delete(files.activeFile);
+
+          tab.textContent = name;
+          const newTab = tab.cloneNode(true) as HTMLAnchorElement;
+          newTab.textContent = name;
+          newTab.addEventListener('click', (e) => {
+            e.preventDefault();
+            files.activateFile(path);
+          });
+          tab.replaceWith(newTab);
+
+          files.models.set(path, mdl);
+          files.tabs.set(path, newTab);
+          files.originals.set(path, content);
+
+          mdl.setValue(content);
+
+          const closeBtn =
+            newTab.nextElementSibling as HTMLButtonElement | null;
+          if (closeBtn) {
+            const newBtn = closeBtn.cloneNode(true) as HTMLButtonElement;
+            newBtn.addEventListener('click', async (e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              await files.closeTab(path);
+            });
+            closeBtn.replaceWith(newBtn);
+          }
+        }
+      }
+
+      // Fallback
+      if (!mdl) {
+        mdl = editor.createModel(content, 'markdown');
+        files.models.set(path, mdl);
+        files.originals.set(path, content);
+        files.addTab(name, path);
+      }
+
+      tree.addFileToTree(path);
+      files.activateFile(path, name);
+      files.openingFile = false;
+    },
+  );
+
+  // Enable access to the monaco editor command palette.
+  bridge.receive('from:command:palette', (command: string) => {
+    model.focus();
+    model.trigger(command, 'editor.action.quickCommand', {});
+  });
+
+  // Enable access to the monaco editor shortcuts modal.
+  bridge.receive('from:modal:open', (modal: ValidModal) => {
+    const handler = providers.commands?.getModal(modal);
+    handler?.toggle();
+  });
+
+  // Enable notifications from the main context.
+  bridge.receive(
+    'from:notification:display',
+    (event: { status: string; message: string }) => {
+      Notify.send(event.status, event.message);
+    },
+  );
+}

--- a/src/browser/lib/bridge/settings.ts
+++ b/src/browser/lib/bridge/settings.ts
@@ -1,0 +1,37 @@
+import { ContextBridgeAPI } from '../../interfaces/Bridge';
+import { editor } from 'monaco-editor/esm/vs/editor/editor.api';
+import { EditorSettings } from '../../interfaces/Editor';
+
+/**
+ * Handle bridge settings logic.
+ */
+export class BridgeSettings {
+  constructor(
+    private bridge: ContextBridgeAPI,
+    private model: editor.IStandaloneCodeEditor,
+  ) {}
+
+  /** Send a save settings request across the bridge */
+  public saveSettingsToFile(settings: EditorSettings) {
+    this.bridge.send('to:settings:save', { settings });
+  }
+
+  /** Load settings for the editor model */
+  public loadSettingsFromStorageChannel(settings: EditorSettings) {
+    this.model.updateOptions({
+      autoIndent: settings.autoindent ? 'advanced' : 'none',
+    });
+
+    this.model.updateOptions({
+      wordWrap: settings.wordwrap ? 'on' : 'off',
+    });
+
+    this.model.updateOptions({
+      renderWhitespace: settings.whitespace ? 'all' : 'none',
+    });
+
+    this.model.updateOptions({
+      minimap: { enabled: settings.minimap },
+    });
+  }
+}


### PR DESCRIPTION
## What's Changed?

- Replaced the bloated `Bridge` implementation with a slimmer orchestrator that delegates work to new helper modules for file management, tree ops, settings and listener registration.
- Added a `FileManager` module to handle tab creation, model tracking, and save operations, keeping file-state logic isolated from the main bridge
- Added a `FileTree` module to build and interact with the file explorer tree structure, removing directory concerns from the core bridge logic
- Centralized all bridge event wiring inside a `registerBridgeListeners` module for clearer, self-contained listener registration.