### PR TITLE
feat: add export settings modal

### DIFF
--- a/src/app/interfaces/Settings.ts
+++ b/src/app/interfaces/Settings.ts
@@ -1,3 +1,11 @@
+export interface ExportSettings {
+  withStyles: boolean;
+  container: 'container' | 'container-fluid';
+  fontSize: number;
+  lineSpacing: number;
+  background: string;
+}
+
 export interface EditorSettings {
   autoindent: boolean;
   darkmode: boolean;
@@ -5,4 +13,8 @@ export interface EditorSettings {
   whitespace: boolean;
   minimap: boolean;
   systemtheme: boolean;
+}
+
+export interface SettingsFile extends EditorSettings {
+  exportSettings: ExportSettings;
 }

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -1,4 +1,4 @@
-import type { EditorSettings } from './interfaces/Editor';
+import type { EditorSettings, ExportSettings } from './interfaces/Editor';
 
 export const config = {};
 
@@ -9,4 +9,12 @@ export const settings: EditorSettings = {
   whitespace: false,
   minimap: true,
   systemtheme: true,
+};
+
+export const exportSettings: ExportSettings = {
+  withStyles: true,
+  container: 'container-fluid',
+  fontSize: 16,
+  lineSpacing: 1.5,
+  background: '#ffffff',
 };

--- a/src/browser/core/BridgeListeners.ts
+++ b/src/browser/core/BridgeListeners.ts
@@ -6,7 +6,7 @@ import type {
   RenamedPath,
 } from '../interfaces/Bridge';
 import type { BridgeProviders, ValidModal } from '../interfaces/Providers';
-import type { EditorSettings } from '../interfaces/Editor';
+import type { SettingsFile } from '../interfaces/Editor';
 import type { EditorDispatcher } from '../events/EditorDispatcher';
 import type { FileManager } from './FileManager';
 import type { FileTreeManager } from './FileTreeManager';
@@ -36,10 +36,12 @@ export function registerBridgeListeners(
   });
 
   // Set settings from stored settings file (%HOME%/.mkeditor/settings.json)
-  bridge.receive('from:settings:set', (s: EditorSettings) => {
+  bridge.receive('from:settings:set', (s: SettingsFile) => {
     settings.loadSettingsFromBridgeListener(s);
     providers.settings?.setSettings(s);
     providers.settings?.registerDOMListeners();
+    providers.exportSettings?.setSettings(s.exportSettings);
+    providers.exportSettings?.registerDOMListeners();
   });
 
   // Enable new files from outside of the renderer execution context.

--- a/src/browser/core/BridgeManager.ts
+++ b/src/browser/core/BridgeManager.ts
@@ -1,7 +1,7 @@
 import type { editor } from 'monaco-editor/esm/vs/editor/editor.api';
 import type { ContextBridgeAPI } from '../interfaces/Bridge';
 import type { BridgeProviders } from '../interfaces/Providers';
-import type { EditorSettings } from '../interfaces/Editor';
+import type { SettingsFile } from '../interfaces/Editor';
 import type { EditorDispatcher } from '../events/EditorDispatcher';
 import { FileManager } from './FileManager';
 import { FileTreeManager } from './FileTreeManager';
@@ -30,6 +30,7 @@ export class BridgeManager {
     settings: null,
     commands: null,
     completion: null,
+    exportSettings: null,
   };
 
   /** File manager helper */
@@ -119,7 +120,7 @@ export class BridgeManager {
    * @param settings - the settings to save.
    * @returns
    */
-  public saveSettingsToFile(settings: EditorSettings) {
+  public saveSettingsToFile(settings: Partial<SettingsFile>) {
     this.settings.saveSettingsToFile(settings);
   }
 

--- a/src/browser/core/BridgeSettings.ts
+++ b/src/browser/core/BridgeSettings.ts
@@ -1,6 +1,6 @@
 import type { editor } from 'monaco-editor/esm/vs/editor/editor.api';
 import type { ContextBridgeAPI } from '../interfaces/Bridge';
-import type { EditorSettings } from '../interfaces/Editor';
+import type { EditorSettings, SettingsFile } from '../interfaces/Editor';
 
 /**
  * Handle bridge settings logic.
@@ -23,7 +23,7 @@ export class BridgeSettings {
    * @param settings - the editor settings
    * @returns
    */
-  public saveSettingsToFile(settings: EditorSettings) {
+  public saveSettingsToFile(settings: Partial<SettingsFile>) {
     this.bridge.send('to:settings:save', { settings });
   }
 
@@ -33,7 +33,7 @@ export class BridgeSettings {
    * @param settings - the settings to load
    * @returns
    */
-  public loadSettingsFromBridgeListener(settings: EditorSettings) {
+  public loadSettingsFromBridgeListener(settings: SettingsFile) {
     this.mkeditor.updateOptions({
       autoIndent: settings.autoindent ? 'advanced' : 'none',
     });

--- a/src/browser/core/HTMLExporter.ts
+++ b/src/browser/core/HTMLExporter.ts
@@ -1,4 +1,5 @@
 import { dom } from '../dom';
+import type { ExportSettings } from '../interfaces/Editor';
 
 const cdn = {
   bootstrap: {
@@ -102,7 +103,13 @@ export class HTMLExporter {
    */
   static generateHTML(
     content: string,
-    { styled = true, container = 'container-fluid' },
+    {
+      styled = true,
+      container = 'container-fluid',
+      fontSize = 16,
+      lineSpacing = 1.5,
+      background = '#ffffff',
+    }: ExportSettings,
   ) {
     // If using bootstrap styles then wrap the content inside a container with padding
     if (styled) {
@@ -150,6 +157,10 @@ export class HTMLExporter {
         elem.removeAttribute('class');
       }
     }
+
+    document.body.style.fontSize = `${fontSize}px`;
+    document.body.style.lineHeight = lineSpacing.toString();
+    document.body.style.backgroundColor = background;
 
     return `<!DOCTYPE html>${document.documentElement.outerHTML}`;
   }

--- a/src/browser/core/providers/ExportSettingsProvider.ts
+++ b/src/browser/core/providers/ExportSettingsProvider.ts
@@ -1,0 +1,108 @@
+import type { EditorDispatcher } from '../../events/EditorDispatcher';
+import type { ExportSettings } from '../../interfaces/Editor';
+import { exportSettings as defaults } from '../../config';
+import { dom } from '../../dom';
+
+export class ExportSettingsProvider {
+  private mode: 'web' | 'desktop' = 'web';
+  private dispatcher: EditorDispatcher;
+  private settings: ExportSettings = defaults;
+  private registered = false;
+
+  constructor(mode: 'web' | 'desktop', dispatcher: EditorDispatcher) {
+    this.mode = mode;
+    this.dispatcher = dispatcher;
+    this.loadSettings();
+    this.registerDOMListeners();
+  }
+
+  public getSettings() {
+    return this.settings;
+  }
+
+  public setSettings(settings: ExportSettings) {
+    this.settings = settings;
+    this.setUIState();
+  }
+
+  private loadSettings() {
+    if (this.mode === 'web') {
+      const storage = localStorage.getItem('mkeditor-export-settings');
+      if (storage) {
+        this.settings = JSON.parse(storage) as ExportSettings;
+      } else {
+        this.updateSettingsInLocalStorage();
+      }
+    }
+    this.setUIState();
+  }
+
+  public setUIState() {
+    const { exports: ex, buttons } = dom;
+    if (!ex) return;
+    ex.withStyles.checked = this.settings.withStyles;
+    ex.container.value = this.settings.container;
+    ex.fontSize.value = this.settings.fontSize.toString();
+    ex.lineSpacing.value = this.settings.lineSpacing.toString();
+    ex.background.value = this.settings.background;
+    const toolbar = buttons.save.styled as HTMLInputElement;
+    if (toolbar) {
+      toolbar.checked = this.settings.withStyles;
+    }
+  }
+
+  public registerDOMListeners() {
+    if (this.registered) return;
+    this.registered = true;
+    const { exports: ex, buttons } = dom;
+    ex.withStyles.addEventListener('change', (e) => {
+      const target = e.target as HTMLInputElement;
+      this.settings.withStyles = target.checked;
+      const toolbar = buttons.save.styled as HTMLInputElement;
+      if (toolbar) toolbar.checked = target.checked;
+      this.persist();
+    });
+    ex.container.addEventListener('change', (e) => {
+      const target = e.target as HTMLSelectElement;
+      this.settings.container = target.value as 'container' | 'container-fluid';
+      this.persist();
+    });
+    ex.fontSize.addEventListener('change', (e) => {
+      const target = e.target as HTMLInputElement;
+      this.settings.fontSize = parseInt(target.value, 10);
+      this.persist();
+    });
+    ex.lineSpacing.addEventListener('input', (e) => {
+      const target = e.target as HTMLInputElement;
+      this.settings.lineSpacing = parseFloat(target.value);
+      this.persist();
+    });
+    ex.background.addEventListener('change', (e) => {
+      const target = e.target as HTMLInputElement;
+      this.settings.background = target.value;
+      this.persist();
+    });
+    const toolbar = buttons.save.styled as HTMLInputElement;
+    if (toolbar) {
+      toolbar.addEventListener('change', (e) => {
+        const target = e.target as HTMLInputElement;
+        this.settings.withStyles = target.checked;
+        ex.withStyles.checked = target.checked;
+        this.persist();
+      });
+    }
+  }
+
+  private updateSettingsInLocalStorage() {
+    localStorage.setItem('mkeditor-export-settings', JSON.stringify(this.settings));
+  }
+
+  private persist() {
+    this.setUIState();
+    if (this.mode === 'web') {
+      this.updateSettingsInLocalStorage();
+    } else {
+      this.dispatcher.bridgeSettings({ settings: { exportSettings: this.settings } });
+    }
+  }
+}

--- a/src/browser/dom.ts
+++ b/src/browser/dom.ts
@@ -33,6 +33,24 @@ export const dom = {
       document.querySelector('#app-settings-file-info')
     ),
   },
+  exports: {
+    modal: <HTMLDivElement>document.querySelector('#export-settings'),
+    withStyles: <HTMLInputElement>document.querySelector(
+      '#export-setting-styles',
+    ),
+    container: <HTMLSelectElement>document.querySelector(
+      '#export-setting-container',
+    ),
+    fontSize: <HTMLInputElement>document.querySelector(
+      '#export-setting-fontsize',
+    ),
+    lineSpacing: <HTMLInputElement>document.querySelector(
+      '#export-setting-linespacing',
+    ),
+    background: <HTMLInputElement>document.querySelector(
+      '#export-setting-background',
+    ),
+  },
   icons: {
     darkmode: <HTMLLabelElement>document.querySelector('#darkmode-icon'),
   },
@@ -43,10 +61,13 @@ export const dom = {
     ),
     save: {
       settings: <HTMLButtonElement>document.querySelector('#app-settings-save'),
+      exportSettings: <HTMLButtonElement>(
+        document.querySelector('#export-settings-save')
+      ),
       markdown: <HTMLButtonElement>document.querySelector('#app-markdown-save'),
       html: <HTMLButtonElement>document.querySelector('#export-to-html'),
       pdf: <HTMLButtonElement>document.querySelector('#export-to-pdf'),
-      styled: <HTMLButtonElement>document.querySelector('#export-with-styles'),
+      styled: <HTMLInputElement>document.querySelector('#export-with-styles'),
     },
     resetSplit: <HTMLButtonElement>document.querySelector('#split-reset'),
   },

--- a/src/browser/events/EditorDispatcher.ts
+++ b/src/browser/events/EditorDispatcher.ts
@@ -1,4 +1,4 @@
-import type { EditorSettings } from '../interfaces/Editor';
+import type { SettingsFile } from '../interfaces/Editor';
 import { BaseDispatcher } from './Dispatcher';
 
 export class EditorDispatcher extends BaseDispatcher {
@@ -23,7 +23,7 @@ export class EditorDispatcher extends BaseDispatcher {
     });
   }
 
-  bridgeSettings({ settings }: { settings: EditorSettings }) {
+  bridgeSettings({ settings }: { settings: Partial<SettingsFile> }) {
     this.dispatchEvent({
       type: 'editor:bridge:settings',
       message: settings,

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -5,6 +5,7 @@ import { CompletionProvider } from './core/providers/CompletionProvider';
 import { CommandProvider } from './core/providers/CommandProvider';
 import { MkedLinkProvider } from './core/providers/MkedLinkProvider';
 import { SettingsProvider } from './core/providers/SettingsProvider';
+import { ExportSettingsProvider } from './core/providers/ExportSettingsProvider';
 import { BridgeManager } from './core/BridgeManager';
 import {
   dom,
@@ -50,10 +51,14 @@ if (mkeditor) {
 
   // Register a new settings handler for the editor to provide editor settings
   // and to persist settings either to localStorage or file depending on context.
-  editorManager.provide(
-    'settings',
-    new SettingsProvider(mode, mkeditor, dispatcher),
+  const settingsProvider = new SettingsProvider(mode, mkeditor, dispatcher);
+  editorManager.provide('settings', settingsProvider);
+
+  const exportSettingsProvider = new ExportSettingsProvider(
+    mode,
+    dispatcher,
   );
+  editorManager.provide('exportSettings', exportSettingsProvider);
 
   // Register a new completion provider for the editor auto-completion
   editorManager.provide(
@@ -70,6 +75,10 @@ if (mkeditor) {
     // Attach providers.
     bridgeManager.provide('settings', editorManager.providers.settings);
     bridgeManager.provide('commands', editorManager.providers.commands);
+    bridgeManager.provide(
+      'exportSettings',
+      editorManager.providers.exportSettings,
+    );
     editorManager.provide('bridge', bridgeManager);
 
     // Register link provider for mked:// navigation for linked documents.

--- a/src/browser/interfaces/Editor.ts
+++ b/src/browser/interfaces/Editor.ts
@@ -1,5 +1,13 @@
 import type { Selection, editor } from 'monaco-editor/esm/vs/editor/editor.api';
 
+export interface ExportSettings {
+  withStyles: boolean;
+  container: 'container' | 'container-fluid';
+  fontSize: number;
+  lineSpacing: number;
+  background: string;
+}
+
 export interface EditorSettings {
   autoindent: boolean;
   darkmode: boolean;
@@ -7,6 +15,10 @@ export interface EditorSettings {
   whitespace: boolean;
   minimap: boolean;
   systemtheme: boolean;
+}
+
+export interface SettingsFile extends EditorSettings {
+  exportSettings: ExportSettings;
 }
 export interface EditorCommand extends Omit<editor.IActionDescriptor, 'run'> {
   isInline: boolean;

--- a/src/browser/interfaces/Providers.ts
+++ b/src/browser/interfaces/Providers.ts
@@ -3,12 +3,14 @@ import type { BridgeManager } from '../core/BridgeManager';
 import type { CommandProvider } from '../core/providers/CommandProvider';
 import type { SettingsProvider } from '../core/providers/SettingsProvider';
 import type { CompletionProvider } from '../core/providers/CompletionProvider';
+import type { ExportSettingsProvider } from '../core/providers/ExportSettingsProvider';
 
 export interface Providers {
   bridge: BridgeManager | null;
   commands: CommandProvider | null;
   completion: CompletionProvider | null;
   settings: SettingsProvider | null;
+  exportSettings: ExportSettingsProvider | null;
 }
 
 export interface ModalProviders {

--- a/src/browser/views/index.html
+++ b/src/browser/views/index.html
@@ -471,6 +471,15 @@
             <span class="d-none d-md-inline">with styles</span>
           </label>
         </div>
+        <a
+          href="#"
+          class="text-muted ms-2"
+          data-bs-toggle="modal"
+          data-bs-target="#export-settings"
+          title="Export settings"
+        >
+          <i class="fas fa-sliders-h"></i>
+        </a>
       </div>
       <ul
         class="navbar-nav ms-auto d-none d-md-flex flex-row align-items-center"
@@ -612,6 +621,105 @@
             <div class="form-group d-flex align-items-center gap-3 mt-4 mb-3">
               <button
                 id="app-settings-save"
+                class="btn btn-sm btn-primary rounded-1"
+              >
+                <i class="fas fa-save"></i>
+                <span class="ms-1">Save Settings</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- export settings modal -->
+    <div class="modal" tabindex="-1" id="export-settings">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header border-bottom-0">
+            <h5 class="modal-title">Export settings</h5>
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="Close"
+            ></button>
+          </div>
+          <div class="modal-body small pt-0">
+            <p class="text-muted">
+              Configure export options for HTML and PDF.
+            </p>
+            <hr />
+            <div class="form-check">
+              <input
+                type="checkbox"
+                class="form-check-input"
+                id="export-setting-styles"
+              />
+              <label
+                class="form-check-label d-flex flex-column"
+                for="export-setting-styles"
+              >
+                <span>With styles</span>
+                <small class="text-muted"
+                  >Enable this to export with styles</small
+                >
+              </label>
+            </div>
+            <div class="form-group mt-3">
+              <label for="export-setting-container" class="form-label"
+                >Set container</label
+              >
+              <select
+                id="export-setting-container"
+                class="form-select form-select-sm"
+              >
+                <option value="container">container</option>
+                <option value="container-fluid">container-fluid</option>
+              </select>
+              <small class="text-muted"
+                >Set the container property on the export</small
+              >
+            </div>
+            <div class="form-group mt-3">
+              <label for="export-setting-fontsize" class="form-label"
+                >Set font-size</label
+              >
+              <input
+                type="number"
+                id="export-setting-fontsize"
+                class="form-control form-control-sm"
+                min="8"
+                max="72"
+              />
+            </div>
+            <div class="form-group mt-3">
+              <label for="export-setting-linespacing" class="form-label"
+                >Set line-spacing</label
+              >
+              <input
+                type="range"
+                id="export-setting-linespacing"
+                class="form-range"
+                min="1"
+                max="3"
+                step="0.1"
+              />
+            </div>
+            <div class="form-group mt-3">
+              <label for="export-setting-background" class="form-label"
+                >Set background colour</label
+              >
+              <input
+                type="text"
+                id="export-setting-background"
+                class="form-control form-control-sm"
+                placeholder="#ffffff"
+              />
+            </div>
+            <div class="form-group d-flex align-items-center gap-3 mt-4 mb-3">
+              <button
+                id="export-settings-save"
                 class="btn btn-sm btn-primary rounded-1"
               >
                 <i class="fas fa-save"></i>


### PR DESCRIPTION
## Summary
- add dedicated Export Settings modal to configure HTML/PDF export options
- persist export preferences in settings.json and sync toolbar state
- apply export settings (container, typography, background) during HTML/PDF generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abc50244388323a5d5cdc145297b98