### PR TITLE
Fix splash issue

### DIFF
--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -163,6 +163,16 @@ let pendingFactories: {
  * the providers, the IPC bridge (desktop), and the splash dismissal.
  */
 function onEditorReady() {
+  try {
+    onEditorReadyInner();
+  } catch (err) {
+    logger?.error('index.onEditorReady', JSON.stringify(err));
+  } finally {
+    showSplashScreen({ duration: 750 });
+  }
+}
+
+function onEditorReadyInner() {
   if (!pendingFactories) {
     logger?.error(
       'index.onEditorReady',
@@ -271,6 +281,4 @@ function onEditorReady() {
     fileManager: bridgeManager.fileManager,
     fileTreeManager: bridgeManager.fileTreeManager,
   }));
-
-  showSplashScreen({ duration: 750 });
 }

--- a/src/browser/util.ts
+++ b/src/browser/util.ts
@@ -4,7 +4,19 @@ import type Renderer from 'markdown-it/lib/renderer.mjs';
 import type { ContextBridgeAPI } from './interfaces/Bridge';
 import type { ExportSettings } from './interfaces/Editor';
 
-export const logger = window.logger;
+// In desktop builds the Electron preload exposes `window.logger`, which
+// forwards to electron-log on the main side. In web builds there is no
+// preload, so without a fallback every `logger?.error(...)` call in the
+// renderer becomes a silent no-op — which has hidden real boot failures
+// (e.g. a stuck splash with no console trail). The fallback below pipes
+// to `console.*` so the same failures surface in DevTools on the web.
+export const logger: NonNullable<Window['logger']> = window.logger ?? {
+  log: (level, msg, meta) => console.log(`[${level}] ${msg}`, meta),
+  debug: (msg, meta) => console.debug(msg, meta),
+  info: (msg, meta) => console.info(msg, meta),
+  warn: (msg, meta) => console.warn(msg, meta),
+  error: (msg, meta) => console.error(msg, meta),
+};
 
 /**
  * Debounce to delay execution.


### PR DESCRIPTION
# Pull Request: Fix issue with hanging splash screen


In web mode, window.logger is undefined (only the Electron preload sets it — util.ts:7 just re-exports it). So every logger?.error(...) call in the renderer is a no-op when running on the web. There are two of them in onEditorReady (index.ts:166-171 and index.ts:186-191) that early-return without calling showSplashScreen(). There's a third silent one inside EditorManager.create() — Monaco's editor.create() is wrapped in a try/catch that swallows the throw and sets this.mkeditor = null, which is exactly what trips the if (!mkeditor) early return in onEditorReady.
So when Monaco's create intermittently throws on refresh (worker setup race, detached mount, etc.):

- EditorManager catches it → silent logger?.error in web → mkeditor stays null
- <EditorHost> fires onReady anyway (it doesn't check the result)
- onEditorReady early-returns silently — showSplashScreen never runs
- Splash stays up, no console message

Two complementary fixes:

A. Web-mode logger fallback that pipes to console.* so silent failures stop being silent.

B. Make splash dismissal unconditional — wrap onEditorReady's body in try { ... } finally { showSplashScreen(...) } (or fire splash before the early returns). A failed boot is bad, but a stuck splash hiding the (broken) editor is worse — user at least sees something.
