### PR TITLE
v3.8.1 - Minor bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+### 2026-05-17 - v3.8.1
+
+#### Fixed
+
+- Fixed issue with react-resizable-panels fighting monaco editor and causing overflow issues.
+- Fixed issue with splash screen hanging on web due to electron logger no-op
+
+---
+
 ### 2026-05-17 - v3.8.0
 
 #### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # MKEditor — Project Context
 
-Electron-based markdown editor built around Monaco. The same TypeScript bundle ships as a desktop app (Electron wraps it) and as a pure web app (deployed to GitHub Pages). Current version: 3.8.0.
+Electron-based markdown editor built around Monaco. The same TypeScript bundle ships as a desktop app (Electron wraps it) and as a pure web app (deployed to GitHub Pages). Current version: 3.8.1.
 
 The renderer is React 19 + shadcn/ui + Tailwind v4 on top of a set of plain-TS managers (Monaco, files, settings, markdown, IPC bridge). Migration history: [docs/REACT_MIGRATION.md](docs/REACT_MIGRATION.md). Subsystem READMEs: [src/app/README.md](src/app/README.md), [src/browser/README.md](src/browser/README.md), [src/browser/extensions/README.md](src/browser/extensions/README.md). For deeper detail see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md). For planned work see [docs/ROADMAP.md](docs/ROADMAP.md).
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Markdown with _style_.
 
 | Platform    | Stable  | Download  |
 | --------    | ------- | -------   |
-| Windows     | v3.8.0  | [exe](https://github.com/versyxdigital/mkeditor/releases/download/v3.8.0/mkeditor-setup-3.8.0.exe) |
+| Windows     | v3.8.1  | [exe](https://github.com/versyxdigital/mkeditor/releases/download/v3.8.1/mkeditor-setup-3.8.1.exe) |
 | MacOS       | v3.6.0  | [pkg](https://github.com/versyxdigital/mkeditor/releases/download/v3.6.0/mkeditor-setup-3.6.0.pkg) |
-| Linux       | v3.8.0  | [deb](https://github.com/versyxdigital/mkeditor/releases/download/v3.8.0/mkeditor-setup-3.8.0.deb)  |
+| Linux       | v3.8.1  | [deb](https://github.com/versyxdigital/mkeditor/releases/download/v3.8.1/mkeditor-setup-3.8.1.deb)  |
 
 > [!NOTE] 
 > Supported languages:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mkeditor",
   "productName": "MKEditor",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "license": "MIT",
   "author": "Chris Rowles <christopher.rowles@outlook.com>",
   "description": "Markdown Editor",

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -163,6 +163,16 @@ let pendingFactories: {
  * the providers, the IPC bridge (desktop), and the splash dismissal.
  */
 function onEditorReady() {
+  try {
+    onEditorReadyInner();
+  } catch (err) {
+    logger?.error('index.onEditorReady', JSON.stringify(err));
+  } finally {
+    showSplashScreen({ duration: 750 });
+  }
+}
+
+function onEditorReadyInner() {
   if (!pendingFactories) {
     logger?.error(
       'index.onEditorReady',
@@ -271,6 +281,4 @@ function onEditorReady() {
     fileManager: bridgeManager.fileManager,
     fileTreeManager: bridgeManager.fileTreeManager,
   }));
-
-  showSplashScreen({ duration: 750 });
 }

--- a/src/browser/react/components/Workspace.tsx
+++ b/src/browser/react/components/Workspace.tsx
@@ -34,7 +34,17 @@ export const Workspace: React.FC<WorkspaceProps> = ({
 
   return (
     <Group orientation="horizontal" id="editor-preview" groupRef={groupRef}>
-      <Panel id="editor-pane" onResize={() => editorManager?.layout()}>
+      <Panel
+        id="editor-pane"
+        onResize={() => editorManager?.layout()}
+        // `react-resizable-panels` v4 puts an inner `<div>` with inline
+        // `overflow: auto` around the panel children. Monaco owns its own
+        // scrollbars, so leaving that div scrollable lets the two compete:
+        // on smaller viewports the pane jumps as both fight to keep the
+        // cursor in view. Forcing `overflow: hidden` cedes scrolling to
+        // Monaco entirely.
+        style={{ overflow: 'hidden' }}
+      >
         <EditorHost onReady={onEditorReady} />
       </Panel>
       <Separator className="gutter gutter-horizontal" />

--- a/src/browser/util.ts
+++ b/src/browser/util.ts
@@ -4,7 +4,19 @@ import type Renderer from 'markdown-it/lib/renderer.mjs';
 import type { ContextBridgeAPI } from './interfaces/Bridge';
 import type { ExportSettings } from './interfaces/Editor';
 
-export const logger = window.logger;
+// In desktop builds the Electron preload exposes `window.logger`, which
+// forwards to electron-log on the main side. In web builds there is no
+// preload, so without a fallback every `logger?.error(...)` call in the
+// renderer becomes a silent no-op — which has hidden real boot failures
+// (e.g. a stuck splash with no console trail). The fallback below pipes
+// to `console.*` so the same failures surface in DevTools on the web.
+export const logger: NonNullable<Window['logger']> = window.logger ?? {
+  log: (level, msg, meta) => console.log(`[${level}] ${msg}`, meta),
+  debug: (msg, meta) => console.debug(msg, meta),
+  info: (msg, meta) => console.info(msg, meta),
+  warn: (msg, meta) => console.warn(msg, meta),
+  error: (msg, meta) => console.error(msg, meta),
+};
 
 /**
  * Debounce to delay execution.

--- a/src/browser/version.ts
+++ b/src/browser/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '3.8.0';
+export const APP_VERSION = '3.8.1';


### PR DESCRIPTION
# What's Changed?

- Fixed issue with react-resizable-panels fighting monaco editor and causing overflow issues.
- Fixed issue with splash screen hanging on web due to electron logger no-op